### PR TITLE
Allows getting the avatar of the specified chat member

### DIFF
--- a/ehforwarderbot/channel.py
+++ b/ehforwarderbot/channel.py
@@ -257,6 +257,33 @@ class SlaveChannel(Channel, ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def get_msg_picture(self, msg: 'Message') -> BinaryIO:
+        """get_msg_picture(msg: Message) -> BinaryIO
+
+        Get the profile picture of a message sender. Profile picture is
+        also referred as profile photo, avatar, "head image"
+        sometimes.
+
+        Args:
+            msg (.Message): Message to get picture from.
+
+        Returns:
+            BinaryIO: Opened temporary file object.
+            The file object MUST have appropriate extension name
+            that matches to the format of picture sent,
+            and seek to position 0.
+
+            It MAY be deleted or discarded once closed, if not needed otherwise.
+
+        Raises:
+            EFBMessageNotFound:
+                Raised when a message required is not found.
+            EFBOperationNotSupported:
+                Raised when the chat does not offer a profile picture.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def get_chat(self, chat_uid: ChatID) -> 'Chat':
         """
         Get the chat object from a slave channel.

--- a/ehforwarderbot/channel.py
+++ b/ehforwarderbot/channel.py
@@ -7,7 +7,7 @@ from .constants import MsgType
 from .types import ModuleID, InstanceID, ExtraCommandName, ReactionName, ChatID, MessageID
 
 if TYPE_CHECKING:
-    from .chat import Chat
+    from .chat import Chat, ChatMember
     from .message import Message
     from .status import Status
 
@@ -257,15 +257,15 @@ class SlaveChannel(Channel, ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_msg_picture(self, msg: 'Message') -> BinaryIO:
-        """get_msg_picture(msg: Message) -> BinaryIO
+    def get_chat_member_picture(self, chat_member: 'ChatMember') -> BinaryIO:
+        """get_chat_member_picture(chat_member: ChatMember) -> BinaryIO
 
-        Get the profile picture of a message sender. Profile picture is
+        Get the profile picture of a chat member. Profile picture is
         also referred as profile photo, avatar, "head image"
         sometimes.
 
         Args:
-            msg (.Message): Message to get picture from.
+            chat_member(.ChatMember): Chat member to get picture from.
 
         Returns:
             BinaryIO: Opened temporary file object.
@@ -276,8 +276,8 @@ class SlaveChannel(Channel, ABC):
             It MAY be deleted or discarded once closed, if not needed otherwise.
 
         Raises:
-            EFBMessageNotFound:
-                Raised when a message required is not found.
+            EFBChatMemberNotFound:
+                Raised when a chat member required is not found.
             EFBOperationNotSupported:
                 Raised when the chat does not offer a profile picture.
         """

--- a/ehforwarderbot/exceptions.py
+++ b/ehforwarderbot/exceptions.py
@@ -70,3 +70,12 @@ class EFBMessageReactionNotPossible(EFBException):
     Can be raised in :meth:`.Channel.send_status`.
     """
     pass
+
+
+class EFBChatMemberNotFound(EFBException):
+    """
+    Raised by a slave channel when a chat member indicated is not found.
+
+    Can be raised in :meth:`.Channel.get_chat_member_picture`
+    """
+    pass


### PR DESCRIPTION
I noticed that **ehforwarderbot** only allows to use **get_chat_picture** method to get group avatars or private chat avatars, but it cannot get the avatar of a specific message sender. So try to add **get_chat_member_picture** method to solve this problem. This requires both the framework and the slaves to make corresponding adaptations.